### PR TITLE
add mcjedl.com

### DIFF
--- a/lists/minecraft.yaml
+++ b/lists/minecraft.yaml
@@ -717,6 +717,9 @@
 - domain: mchacks.net
   notes: Malware alert!
   path: /
+- domain: mcjedl.com
+  notes: /
+  path: /
   reason: Illegal redistribution
 - domain: mcleaks.net
   notes: Alt Generator


### PR DESCRIPTION
Discovered this when it was [added to a FTB Wiki page](https://ftb.fandom.com/wiki/Special:Permalink/869533) mistakenly.

**Yes, I know this project is unmaintained and probably won't be merged for a long time.** I'm just submitting this for posterity.